### PR TITLE
Add redis module

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -3,3 +3,5 @@ MONGO_URI=mongodb://localhost:27017
 MONGO_DB_NAME=myply
 YOUTUBE_API_KEY=
 MONGO_TTL=30
+REDIS_URI=redis://:@localhost:6379/1
+REDIS_TIMEOUT=30

--- a/application/server.go
+++ b/application/server.go
@@ -36,7 +36,7 @@ func New() (*fiber.App, error) {
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 // @host localhost:8080
 // @BasePath /
-func NewServer(config *configs.Config, logger *zap.SugaredLogger, mongo *db.MongoInstance) *fiber.App {
+func NewServer(config *configs.Config, logger *zap.SugaredLogger, mongo *db.MongoInstance, rdb *db.RedisInstance) *fiber.App {
 	// TODO: move to repository
 	collection := mongo.Db.Collection("members")
 	member := persistence.Member{
@@ -47,7 +47,6 @@ func NewServer(config *configs.Config, logger *zap.SugaredLogger, mongo *db.Mong
 	// TODO: move to api
 	insertionResult, _ := collection.InsertOne(context.Background(), member)
 	logger.Infof("Instance\n%+v", insertionResult)
-	
 
 	logger.Infof("Configuration settings\n%+v", config)
 	app := fiber.New()

--- a/application/wire_gen.go
+++ b/application/wire_gen.go
@@ -39,7 +39,11 @@ func New() (*fiber.App, error) {
 	if err != nil {
 		return nil, err
 	}
-	app := NewServer(config, sugaredLogger, mongoInstance)
+	redisInstance, err := db.NewRedisDB(config)
+	if err != nil {
+		return nil, err
+	}
+	app := NewServer(config, sugaredLogger, mongoInstance, redisInstance)
 	return app, nil
 }
 
@@ -55,7 +59,7 @@ func New() (*fiber.App, error) {
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 // @host localhost:8080
 // @BasePath /
-func NewServer(config *configs.Config, logger2 *zap.SugaredLogger, mongo *db.MongoInstance) *fiber.App {
+func NewServer(config *configs.Config, logger2 *zap.SugaredLogger, mongo *db.MongoInstance, rdb *db.RedisInstance) *fiber.App {
 
 	collection := mongo.Db.Collection("members")
 	member := persistence.Member{

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,9 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/go-redis/redis/v9 v9.0.0-beta.2 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,11 +8,15 @@ github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
@@ -27,6 +31,10 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/swag v0.21.1 h1:wm0rhTb5z7qpJRHBdPOMuY4QjVUMbF6/kwoYeRAOrKU=
 github.com/go-openapi/swag v0.21.1/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-redis/redis/v9 v9.0.0-beta.1 h1:oW3jlPic5HhGUbYMH0lidnP+72BgsT+lCwlVud6o2Mc=
+github.com/go-redis/redis/v9 v9.0.0-beta.1/go.mod h1:6gNX1bXdwkpEG0M/hEBNK/Fp8zdyCkjwwKc6vBbfCDI=
+github.com/go-redis/redis/v9 v9.0.0-beta.2 h1:ZSr84TsnQyKMAg8gnV+oawuQezeJR11/09THcWCQzr4=
+github.com/go-redis/redis/v9 v9.0.0-beta.2/go.mod h1:Bldcd/M/bm9HbnNPi/LUtYBSD8ttcZYBMupwMXhdU0o=
 github.com/gofiber/fiber/v2 v2.32.0/go.mod h1:CMy5ZLiXkn6qwthrl03YMyW1NLfj0rhxz2LKl4t7ZTY=
 github.com/gofiber/fiber/v2 v2.34.1 h1:C6saXB7385HvtXX+XMzc5Dqj5S/aEXOfKCW7JNep4rA=
 github.com/gofiber/fiber/v2 v2.34.1/go.mod h1:ozRQfS+D7EL1+hMH+gutku0kfx1wLX4hAxDCtDzpj4U=
@@ -37,6 +45,7 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/infrastructure/configs/config.go
+++ b/infrastructure/configs/config.go
@@ -16,10 +16,12 @@ type Phase int64
 
 // Config is myply' configuration instance, singleton
 type Config struct {
-	Phase       Phase
-	MongoURI    string
-	MongoDBName string
-	MongoTTL    time.Duration
+	Phase        Phase
+	MongoURI     string
+	MongoDBName  string
+	MongoTTL     time.Duration
+	RedisURI     string
+	RedisTimeout time.Duration
 }
 
 const (
@@ -69,10 +71,16 @@ func NewConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	redisTimeout, err := strconv.Atoi(os.Getenv("REDIS_TIMEOUT"))
+	if err != nil {
+		return nil, err
+	}
 	return &Config{
-		Phase:       phase,
-		MongoURI:    os.Getenv("MONGO_URI"),
-		MongoDBName: os.Getenv("MONGO_DB_NAME"),
-		MongoTTL:    time.Duration(mongoTTL) * time.Second,
+		Phase:        phase,
+		MongoURI:     os.Getenv("MONGO_URI"),
+		MongoDBName:  os.Getenv("MONGO_DB_NAME"),
+		MongoTTL:     time.Duration(mongoTTL) * time.Second,
+		RedisURI:     os.Getenv("REDIS_URI"),
+		RedisTimeout: time.Duration(redisTimeout) * time.Second,
 	}, nil
 }

--- a/infrastructure/persistence/db/mongo.go
+++ b/infrastructure/persistence/db/mongo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/wire"
 )
 
-var Set = wire.NewSet(NewMongoDB)
+var Set = wire.NewSet(NewMongoDB, NewRedisDB)
 
 // MongoInstance contains the Mongo client and database objects
 type MongoInstance struct {

--- a/infrastructure/persistence/db/redis.go
+++ b/infrastructure/persistence/db/redis.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/Nexters/myply/infrastructure/configs"
+	"github.com/go-redis/redis/v9"
+)
+
+type RedisInstance struct {
+	Client  *redis.Client
+	timeout time.Duration
+}
+
+func NewRedisDB(config *configs.Config) (*RedisInstance, error) {
+	clientOptions, err := redis.ParseURL(config.RedisURI)
+
+	if err != nil {
+		return nil, err
+	}
+
+	rdb := redis.NewClient(clientOptions)
+
+	return &RedisInstance{Client: rdb, timeout: config.RedisTimeout}, nil
+}
+
+func (rdb *RedisInstance) SetNXJson(key string, data interface{}, ttl time.Duration) error {
+	b, jsonErr := json.Marshal(data)
+	if jsonErr != nil {
+		return jsonErr
+	}
+
+	ctx, cancel := rdb.createCtx()
+	defer cancel()
+
+	_, err := rdb.Client.SetNX(ctx, key, b, ttl).Result()
+
+	return err
+}
+
+func (rdb *RedisInstance) GetJson(key string, model interface{}) error {
+	ctx, cancel := rdb.createCtx()
+	defer cancel()
+
+	b, err := rdb.Client.Get(ctx, key).Bytes()
+
+	if err != nil {
+		return err
+	}
+
+	json.Unmarshal(b, model)
+
+	return nil
+}
+
+func (rdb *RedisInstance) ZIncrByOne(key string, member string) (float64, error) {
+	ctx, cancel := rdb.createCtx()
+	defer cancel()
+
+	return rdb.Client.ZIncrBy(ctx, key, 1, member).Result()
+}
+
+func (rdb *RedisInstance) ZRevRange(key string, start int64, end int64) ([]string, error) {
+	ctx, cancel := rdb.createCtx()
+	defer cancel()
+
+	return rdb.Client.ZRevRange(ctx, key, start, end).Result()
+}
+
+func (rdb *RedisInstance) createCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), rdb.timeout)
+}


### PR DESCRIPTION
This PR doesn't need to be used as per tomorrow's discussion.
it just something I've been working on before. (can use it later when we need it)

## My point of thinking

### 1. `Set` vs `HSet` vs `JSON.SET`

I decided to use Set memo-ing youtube api for the following reasons.
(ref. https://stackoverflow.com/questions/16375188/redis-strings-vs-redis-hashes-to-represent-json-efficiency)

1. No sub-field access required
2. No need to read only part

### 2. `SetNXJson`

We can also use the method below,
but we have to declare all methods per model (not support Inheritance)

```go
type RedisDataModel struct {
	Val1 string `json:"val1"`
	Val2 int    `json:"val2"`
}

func (m RedisDataModel) MarshalBinary() ([]byte, error) {
	return json.Marshal(m)
}

func (m *RedisDataModel) UnmarshalBinary(b []byte) error {
	return json.Unmarshal(b, m)
}

rdb.SetNX(context.Background(), "rediskey2", &RedisDataModel{"hello", 2022}, time.Hour)
```

So i made a method with json encoding decoding role => `SetNXJson`