### PR TITLE
Feature/60/add pagination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run build clean wire
+.PHONY: test run build clean wire
 
 APP_NAME = apiserver
 GO ?= GO111MODULE=on go
@@ -10,6 +10,9 @@ MIGRATION_DIR = $(PWD)/infrastructure/migrations
 setup:
 	go mod tidy
 	go install github.com/google/wire/cmd/wire@latest
+
+test:
+	go test ./...
 
 # remove binary		
 clean:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -270,6 +270,20 @@ const docTemplate = `{
                 }
             }
         },
+        "controller.ListMusicData": {
+            "type": "object",
+            "properties": {
+                "musics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controller.MusicResponse"
+                    }
+                },
+                "nextPageToken": {
+                    "type": "string"
+                }
+            }
+        },
         "controller.ListMusicResponse": {
             "type": "object",
             "properties": {
@@ -277,10 +291,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/controller.MusicResponse"
-                    }
+                    "$ref": "#/definitions/controller.ListMusicData"
                 },
                 "message": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -263,6 +263,20 @@
                 }
             }
         },
+        "controller.ListMusicData": {
+            "type": "object",
+            "properties": {
+                "musics": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/controller.MusicResponse"
+                    }
+                },
+                "nextPageToken": {
+                    "type": "string"
+                }
+            }
+        },
         "controller.ListMusicResponse": {
             "type": "object",
             "properties": {
@@ -270,10 +284,7 @@
                     "type": "integer"
                 },
                 "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/controller.MusicResponse"
-                    }
+                    "$ref": "#/definitions/controller.ListMusicData"
                 },
                 "message": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,14 +8,21 @@ definitions:
       message:
         type: string
     type: object
+  controller.ListMusicData:
+    properties:
+      musics:
+        items:
+          $ref: '#/definitions/controller.MusicResponse'
+        type: array
+      nextPageToken:
+        type: string
+    type: object
   controller.ListMusicResponse:
     properties:
       code:
         type: integer
       data:
-        items:
-          $ref: '#/definitions/controller.MusicResponse'
-        type: array
+        $ref: '#/definitions/controller.ListMusicData'
       message:
         type: string
     type: object

--- a/domain/musics/index.go
+++ b/domain/musics/index.go
@@ -1,5 +1,13 @@
 package musics
 
-import "github.com/google/wire"
+import (
+	"fmt"
+
+	"github.com/google/wire"
+)
 
 var Set = wire.NewSet(NewMusicService)
+
+func GenerateRedisKey(query, token string) string {
+	return fmt.Sprintf("%s:%s", query, token)
+}

--- a/domain/musics/repository.go
+++ b/domain/musics/repository.go
@@ -1,7 +1,7 @@
 package musics
 
 type MusicRepository interface {
-	GetMusicList(key string) (*Musics, bool, error)
+	GetMusicList(key, pageToken string) (*MusicListDto, bool, error)
 	SaveMusicList(key string, musicList []byte) error
-	GetPlayListBy(order string) (*Musics, error)
+	GetPlayListBy(order, pageToken string) (*MusicListDto, error)
 }

--- a/infrastructure/clients/youtube.go
+++ b/infrastructure/clients/youtube.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+
 	"github.com/Nexters/myply/infrastructure/configs"
 	"google.golang.org/api/option"
 	v3 "google.golang.org/api/youtube/v3"
@@ -27,7 +28,7 @@ const (
 type TagMap map[string][]string
 
 type YoutubeClient interface {
-	SearchPlaylist(q string, order string) (*v3.SearchListResponse, error)
+	SearchPlaylist(q string, order string, pageToken string) (*v3.SearchListResponse, error)
 	ParseVideoIds(items []*v3.SearchResult) []string
 	ParseVideoTags(ids []string) (TagMap, error)
 }
@@ -37,7 +38,7 @@ type youtubeClient struct {
 }
 
 func NewYoutubeClient(config *configs.Config) (YoutubeClient, error) {
-	// TODO: if needed use option.WithGRPCConnectionPool()
+	// if needed use option.WithGRPCConnectionPool()
 	service, err := v3.NewService(
 		context.Background(),
 		option.WithAPIKey(config.YoutubeAPIKey),
@@ -49,7 +50,7 @@ func NewYoutubeClient(config *configs.Config) (YoutubeClient, error) {
 	return &youtubeClient{service}, nil
 }
 
-func (yc *youtubeClient) SearchPlaylist(q string, order string) (*v3.SearchListResponse, error) {
+func (yc *youtubeClient) SearchPlaylist(q, order, pageToken string) (*v3.SearchListResponse, error) {
 	if order == "" {
 		order = defaultOrder
 	}
@@ -58,6 +59,7 @@ func (yc *youtubeClient) SearchPlaylist(q string, order string) (*v3.SearchListR
 		Q(q).
 		Type(targetTypes...).
 		RegionCode(regionCode).
+		PageToken(pageToken). // When pageToken == "", token will be ignored.
 		VideoCategoryId(videoCategory).
 		VideoDuration(videoDuration).
 		Order(order).

--- a/infrastructure/clients/youtube_test.go
+++ b/infrastructure/clients/youtube_test.go
@@ -1,0 +1,30 @@
+package clients
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Nexters/myply/infrastructure/configs"
+)
+
+func setup(t *testing.T) (func(t *testing.T), YoutubeClient) {
+	t.Log("setup test case")
+	youtubeClient, _ := NewYoutubeClient(&configs.Config{
+		YoutubeAPIKey: os.Getenv("YOUTUBE_API_KEY"),
+	})
+
+	return func(t *testing.T) {
+		t.Log("teardown test case")
+	}, youtubeClient
+}
+
+// TestSearchPlaylist test real youtube api
+func TestSearchPlaylist(t *testing.T) {
+	teardown, youtubeClient := setup(t)
+	defer teardown(t)
+
+	res, _ := youtubeClient.SearchPlaylist("beenzino", "", "")
+
+	t.Logf("%+v", res)
+	t.Fail()
+}

--- a/infrastructure/configs/config.go
+++ b/infrastructure/configs/config.go
@@ -79,7 +79,7 @@ func NewConfig() (*Config, error) {
 		MongoURI:              os.Getenv("MONGO_URI"),
 		MongoDBName:           os.Getenv("MONGO_DB_NAME"),
 		MongoTTL:              time.Duration(mongoTTL) * time.Second,
-		MongoCacheTTL:         time.Duration(24*1) * time.Hour, // 1day
+		MongoCacheTTL:         time.Duration(24) * time.Hour, // 1day
 		YoutubeAPIKey:         os.Getenv("YOUTUBE_API_KEY"),
 		StorageCollectionName: os.Getenv("STORAGE_COLLECTION_NAME"),
 	}, nil

--- a/infrastructure/persistence/cache/mongo.go
+++ b/infrastructure/persistence/cache/mongo.go
@@ -17,8 +17,6 @@ import (
 
 var Set = wire.NewSet(NewMongoCacheDB)
 
-const CacheTTL = 24 * 60 * 60
-
 // Storage interface that is implemented by storage providers
 type Storage struct {
 	db    *mongo.Database
@@ -55,12 +53,10 @@ func NewMongoCacheDB(mongoInstance *db.MongoInstance, config *configs.Config) (C
 		// setting to 0
 		// means that documents will remain in the collection
 		// until they're explicitly deleted or the collection is dropped.
-		Options: options.Index().SetExpireAfterSeconds(CacheTTL),
+		Options: options.Index().SetExpireAfterSeconds(0),
 	}
 
-	if _, err := col.Indexes().CreateOne(context.Background(), indexModel); err != nil {
-		return nil, err
-	}
+	col.Indexes().CreateOne(context.Background(), indexModel) // ignore error
 
 	return &Storage{
 		db:  db,

--- a/infrastructure/persistence/member.go
+++ b/infrastructure/persistence/member.go
@@ -24,7 +24,7 @@ type memberRepository struct {
 }
 
 const (
-	memberCollectionName = "membmers"
+	memberCollectionName = "members"
 )
 
 func NewMemberRepository(mongo *db.MongoInstance, config *configs.Config) member.MemberRepository {

--- a/infrastructure/persistence/musics.go
+++ b/infrastructure/persistence/musics.go
@@ -44,14 +44,14 @@ func (m *MusicRepository) buildMusicListResponse(items []*v3.SearchResult) (*mus
 	return &musicListResponse, nil
 }
 
-func (m *MusicRepository) GetMusicList(q string) (musicListResponse *musics.Musics, isCached bool, err error) {
-	data, _ := m.cc.Get(q)
+func (m *MusicRepository) GetMusicList(q, pageToken string) (musicListResponse *musics.MusicListDto, isCached bool, err error) {
+	redisKey := musics.GenerateRedisKey(q, pageToken)
+	data, _ := m.cc.Get(redisKey)
 	if data != nil {
-		if err = json.Unmarshal(data, musicListResponse); err == nil {
+		if err = json.Unmarshal(data, &musicListResponse); err == nil {
+			fmt.Printf("CACHE HIT of %s\n", redisKey)
 			return musicListResponse, true, nil
 		}
-
-		fmt.Println(err.Error())
 	}
 
 	var musicsV3 *v3.SearchListResponse

--- a/infrastructure/persistence/musics.go
+++ b/infrastructure/persistence/musics.go
@@ -22,7 +22,7 @@ func NewMusicRepository(c *configs.Config, cc cache.Cache, yc clients.YoutubeCli
 
 }
 
-func (m *MusicRepository) buildMusicListResponse(items []*v3.SearchResult) (*musics.Musics, error) {
+func (m *MusicRepository) buildMusicListResponse(items []*v3.SearchResult, nextPageToken string) (*musics.MusicListDto, error) {
 	ids := m.yc.ParseVideoIds(items)
 	musicListResponse := make(musics.Musics, len(items))
 	tags, err := m.yc.ParseVideoTags(ids)
@@ -41,7 +41,8 @@ func (m *MusicRepository) buildMusicListResponse(items []*v3.SearchResult) (*mus
 			)
 		}
 	}
-	return &musicListResponse, nil
+	return &musics.MusicListDto{
+		Musics: &musicListResponse, NextPageToken: nextPageToken}, nil
 }
 
 func (m *MusicRepository) GetMusicList(q, pageToken string) (musicListResponse *musics.MusicListDto, isCached bool, err error) {
@@ -55,12 +56,12 @@ func (m *MusicRepository) GetMusicList(q, pageToken string) (musicListResponse *
 	}
 
 	var musicsV3 *v3.SearchListResponse
-	musicsV3, err = m.yc.SearchPlaylist(fmt.Sprintf("playlist,%s", q), "")
+	musicsV3, err = m.yc.SearchPlaylist(fmt.Sprintf("playlist,%s", q), "", pageToken)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if musicListResponse, err = m.buildMusicListResponse(musicsV3.Items); err != nil {
+	if musicListResponse, err = m.buildMusicListResponse(musicsV3.Items, musicsV3.NextPageToken); err != nil {
 		return nil, false, err
 	}
 
@@ -71,14 +72,14 @@ func (m *MusicRepository) SaveMusicList(key string, musicList []byte) error {
 	return m.cc.Set(key, musicList, m.c.MongoCacheTTL)
 }
 
-func (m *MusicRepository) GetPlayListBy(order string) (musicListResponse *musics.Musics, err error) {
+func (m *MusicRepository) GetPlayListBy(order, pageToken string) (musicListResponse *musics.MusicListDto, err error) {
 	var musicsV3 *v3.SearchListResponse
-	musicsV3, err = m.yc.SearchPlaylist("", order)
+	musicsV3, err = m.yc.SearchPlaylist("", order, pageToken)
 	if err != nil {
 		return nil, err
 	}
 
-	if musicListResponse, err = m.buildMusicListResponse(musicsV3.Items); err != nil {
+	if musicListResponse, err = m.buildMusicListResponse(musicsV3.Items, musicsV3.NextPageToken); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Change Logs
- #60 
- fix: mistypo of member collection
- fix: ignore mongo cache index creation error 
- fix: cache hit success
- test: youtube music testcase

## Details

I updated query based redis key to `query:pageToken` because previous key cannot handle pagination.

- AS-IS: `beenzino`
- TO-BE: `beenzino:CBkQAA`
 
Also I added testcase template, which can handle setup and teardown.

E.G.
```go
func setup(t *testing.T) (func(t *testing.T), YoutubeClient) {
	t.Log("setup test case")
	youtubeClient, _ := NewYoutubeClient(&configs.Config{
		YoutubeAPIKey: os.Getenv("YOUTUBE_API_KEY"),
	})

	return func(t *testing.T) {
		t.Log("teardown test case")
	}, youtubeClient
}
```